### PR TITLE
Update server.go

### DIFF
--- a/server.go
+++ b/server.go
@@ -99,17 +99,13 @@ func TLSConfig() *tls.Config {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
-			// no SHA-1, ECDHE before plain RSA, GCM before CBC
-			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
-			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
-			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
-		},
+            		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+            		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+            		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+            		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+            		tls.TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305,
+            		tls.TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305,
+        	},
 	}
 }
 


### PR DESCRIPTION
amend supported TLS ciphers to be inline with current Percona baselines, addresses PMM-7680, this code has not at this time been compiled and is taken from current is known working code example within the baseline document only, please review and ensure functional.