### PR TITLE
PMM-7789 Removed weak cyphers.

### DIFF
--- a/server.go
+++ b/server.go
@@ -99,16 +99,13 @@ func TLSConfig() *tls.Config {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
-			// no SHA-1, ECDHE before plain RSA, GCM before CBC
+			// no SHA-1, no CBC, ECDHE before plain RSA
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
 			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
-			tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
 		},
 	}
 }


### PR DESCRIPTION
CBC cipher is considered vulnerable to LUCKY13 attack.
