### PR TITLE
Revert "Merge pull request #15 from percona/PMM-7789_remove_insecure_…

### DIFF
--- a/server.go
+++ b/server.go
@@ -99,13 +99,16 @@ func TLSConfig() *tls.Config {
 		MinVersion:               tls.VersionTLS12,
 		PreferServerCipherSuites: true,
 		CipherSuites: []uint16{
-			// no SHA-1, no CBC, ECDHE before plain RSA
+			// no SHA-1, ECDHE before plain RSA, GCM before CBC
 			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA256,
 			tls.TLS_RSA_WITH_AES_128_GCM_SHA256,
 			tls.TLS_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_RSA_WITH_AES_128_CBC_SHA256,
 		},
 	}
 }


### PR DESCRIPTION
Reverted PR #15: CBC cipher is considered vulnerable to LUCKY13 attack.

This reverts commit fad100e649a729fed968501f82a62ce0208e7566, reversing
changes made to 6ed5adb5b4587752e46c8b9f9e4e5b79895a06f9.